### PR TITLE
Increase the width of categories section in a course card

### DIFF
--- a/components/Course/Card.vue
+++ b/components/Course/Card.vue
@@ -40,7 +40,7 @@
         <span
           v-if="item.categories?.data.length"
           :title="categories"
-          class="badge badge-sm badge-ghost border-0 line-clamp-1 max-w-[55%]"
+          class="badge badge-sm badge-ghost border-0 line-clamp-1 max-w-[100%]"
         >
           {{ categories }}
         </span>


### PR DESCRIPTION
Closes #44 

Previously only one category was showing in the category badge. I increased its width, so that all the category can be seen in list view.