### PR TITLE
feat: show resources count and disable empty tabs

### DIFF
--- a/components/List/index.vue
+++ b/components/List/index.vue
@@ -8,6 +8,7 @@ type TabItem = {
   title: string;
   value: string;
   indicator?: string | number | null;
+  disabled?: boolean;
 };
 type PaginationOptions = {
   start?: number;
@@ -152,6 +153,7 @@ defineEmits(['searched', 'sorted', 'activeTab', 'activePage', 'switchView']);
           'tab-active font-bold !bg-secondary !text-secondary-content': activeTab === i,
           indicator: tab.indicator,
         }"
+        :disabled="tab.disabled"
         @click="$emit('activeTab', i)"
       >
         <span v-if="tab.indicator" class="indicator-item badge badge-accent">

--- a/components/List/index.vue
+++ b/components/List/index.vue
@@ -69,6 +69,10 @@ const props = defineProps({
     type: String,
     default: null,
   },
+  resourceCount: {
+    type: Number,
+    default: null,
+  },
   activeTab: {
     type: Number,
     default: 0,
@@ -117,6 +121,10 @@ defineEmits(['searched', 'sorted', 'activeTab', 'activePage', 'switchView']);
       <!-- Sort and filter -->
       <div v-if="props.showSort" class="flex flex-wrap mx-auto w-full items-center gap-4">
         <ListSort :sort-options="props.sortOptions" @sort="(q: string) => $emit('sorted', q)" />
+        <span v-if="resourceCount !== null" class="text-sm text-base-content/70">
+          {{ resourceCount }}
+          {{ resourceCount === 1 ? $t('material.resource.title', 1) : $t('material.resource.title', 2) }}
+        </span>
         <slot name="list-option" />
 
         <button

--- a/pages/courses/[id].vue
+++ b/pages/courses/[id].vue
@@ -219,20 +219,49 @@ const switchTab = (t: number) => {
   state.activePage = 1;
 };
 
+onMounted(() => {
+  const tabParam = route.query.tab as string;
+  const pageParam = route.query.page as string;
+
+  if (tabParam) {
+    const tabIndex = tabsList.value.findIndex((tab) => tab.value === tabParam);
+
+    if (tabIndex !== -1) {
+      state.activeTab = tabIndex;
+    }
+  }
+
+  if (pageParam) {
+    const page = Number(pageParam);
+
+    if (!isNaN(page) && page > 0) {
+      state.activePage = page;
+    }
+  }
+});
+
 // Reset to exam tab when course ID changes
 watch(
   () => route.params.id,
   () => {
     state.activeTab = 0;
+    state.activePage = 1;
   },
   { immediate: true },
 );
 
 watch(state, () => {
+  const query: Record<string, string> = {
+    tab: tabsList.value[state.activeTab].value,
+  };
+
+  // Only add page parameter if it's not page 1
+  if (state.activePage > 1) {
+    query.page = state.activePage.toString();
+  }
+
   return navigateTo({
-    query: {
-      tab: tabsList.value[state.activeTab].value,
-    },
+    query,
     replace: true,
   });
 });

--- a/pages/courses/[id].vue
+++ b/pages/courses/[id].vue
@@ -145,6 +145,15 @@ const pageCount = computed(() => {
   return Math.ceil(recordCount.value![0].resource![0].countDistinct.id / 18);
 });
 
+const currentTabResourceCount = computed(() => {
+  if (!recordCount.value || !recordCount.value[0]?.resource || recordCount.value[0].resource.length === 0) return 0;
+  const resources = recordCount.value[0].resource;
+  // @ts-expect-error
+  const count = resources[0]?.countDistinct?.id;
+  if (count) return count;
+  return 0;
+});
+
 const heading = computed<string>(() => (locale.value === 'en' ? course.value!.name_en : course.value!.name_ar));
 
 const switchTab = (t: number) => {
@@ -208,6 +217,7 @@ onMounted(() => {
       :tabs="tabsList"
       :search-placeholder="$t('material.search') + '...'"
       :sort-options="sortOptions"
+      :resource-count="currentTabResourceCount"
       :active-tab="state.activeTab"
       :pagination="{
         end: pageCount,

--- a/pages/courses/[id].vue
+++ b/pages/courses/[id].vue
@@ -219,6 +219,15 @@ const switchTab = (t: number) => {
   state.activePage = 1;
 };
 
+// Reset to exam tab when course ID changes
+watch(
+  () => route.params.id,
+  () => {
+    state.activeTab = 0;
+  },
+  { immediate: true },
+);
+
 watch(state, () => {
   return navigateTo({
     query: {
@@ -226,14 +235,6 @@ watch(state, () => {
     },
     replace: true,
   });
-});
-
-onMounted(() => {
-  const tabs = tabsList.value.map((i) => i.value);
-
-  if (route.query.tab && tabs.includes(route.query.tab as 'note' | 'exam')) {
-    state.activeTab = tabs.indexOf(route.query.tab as 'note' | 'exam');
-  }
 });
 </script>
 


### PR DESCRIPTION
Closes #82 

- [x] **Resources Count:** Added the number of notes/exams to the course page.
Note: Implemented as inline text rather than a badge for a cleaner, less cluttered UI.
- [x] **Empty States:** Tabs(exam or notes) with 0 resources are now disabled.
- [x] **Auto-Switching:** If the default tab is empty, the page automatically switches to the non-empty tab.
- [x] Default tab is always set to exam tab.

1) Show the number of resources.
![Screenshot_19-12-2025_194345_localhost](https://github.com/user-attachments/assets/dd4b5ff4-7cfe-45c5-8dc8-6ba5e062df66)

2) Disable and switch tabs
![Screenshot_19-12-2025_194416_localhost](https://github.com/user-attachments/assets/2e72a6db-9db8-4483-bcb5-37c0c6ebd3cd)
